### PR TITLE
Add artist wikipedia link to colophon

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -27,7 +27,7 @@
 			<p>The cover page is adapted from<br/>
 			<i epub:type="se:name.visual-art.painting">The Wyndham Sisters</i>,<br/>
 			a painting completed in 1899 by<br/>
-			<span class="name">John Singer Sargent</span>.<br/>
+			<a href="https://en.wikipedia.org/wiki/John_Singer_Sargent">John Singer Sargent</a>.<br/>
 			The cover and title pages feature the<br/>
 			<span epub:type="se:name.visual-art.typeface">League Spartan</span> and <span epub:type="se:name.visual-art.typeface">Sorts Mill Goudy</span><br/>
 			typefaces created in 2014 and 2009 by<br/>


### PR DESCRIPTION
This was [already in content.opf](https://github.com/standardebooks/max-beerbohm_zuleika-dobson/blob/2af35ca886937ffe698290a5af8142cfd2c19fb7/src/epub/content.opf#L68).